### PR TITLE
Caching and signaling

### DIFF
--- a/app.py
+++ b/app.py
@@ -109,7 +109,16 @@ def launch_app(_):
     if you do the following in the global scope--which you may be
     tempted to do because we are only doing it once!
     """
-    data_ = read_data()
+    # Some default vals
+    get_data_args = {
+        "show_clade_defining": False,
+        "hidden_strains": [],
+        "strain_order": [],
+        "min_mutation_freq": None,
+        "max_mutation_freq": None
+    }
+    data_ = read_data(get_data_args)
+
     return [
         # Bootstrap row containing tools at the top of the application
         toolbar_generator.get_toolbar_row(data_),
@@ -134,10 +143,11 @@ def launch_app(_):
         dcc.Store(id="data", data=data_),
         # The following in-browser variables simply exist to help
         # modularize the callbacks below.
-        dcc.Store(id="show-clade-defining"),
+        dcc.Store(id="show-clade-defining",
+                  data=get_data_args["show_clade_defining"]),
         dcc.Store(id="new-upload"),
-        dcc.Store(id="hidden-strains"),
-        dcc.Store(id="strain-order"),
+        dcc.Store(id="hidden-strains", data=get_data_args["hidden_strains"]),
+        dcc.Store(id="strain-order", data=get_data_args["strain_order"]),
         dcc.Store(id="last-heatmap-cell-clicked"),
         # Used to update certain figures only when necessary
         dcc.Store(id="heatmap-x-len", data=len(data_["heatmap_x_nt_pos"])),
@@ -220,13 +230,13 @@ def update_get_data_args(show_clade_defining, new_upload, hidden_strains,
     # We call ``read_data`` here, so it gets cached. Otherwise, the
     # callbacks that call ``read_data`` may do it in parallel--blocking
     # multiple processes.
-    data_ = read_data(args)
+    read_data(args)
 
     return args
 
 
 @cache.memoize()
-def read_data(get_data_args=None):
+def read_data(get_data_args):
     """Returns and caches return value of ``get_data``.
 
     Why is this function necessary?
@@ -252,17 +262,15 @@ def read_data(get_data_args=None):
     :param get_data_args: Args for ``get_data``
     :type get_data_args: dict
     """
-    if get_data_args:
-        return get_data(
-            [REFERENCE_DATA_DIR, USER_DATA_DIR],
-            show_clade_defining=get_data_args["show_clade_defining"],
-            hidden_strains=get_data_args["hidden_strains"],
-            strain_order=get_data_args["strain_order"],
-            min_mutation_freq=get_data_args["min_mutation_freq"],
-            max_mutation_freq=get_data_args["max_mutation_freq"]
-        )
-    else:
-        return get_data([REFERENCE_DATA_DIR, USER_DATA_DIR])
+    ret = get_data(
+        [REFERENCE_DATA_DIR, USER_DATA_DIR],
+        show_clade_defining=get_data_args["show_clade_defining"],
+        hidden_strains=get_data_args["hidden_strains"],
+        strain_order=get_data_args["strain_order"],
+        min_mutation_freq=get_data_args["min_mutation_freq"],
+        max_mutation_freq=get_data_args["max_mutation_freq"]
+    )
+    return ret
 
 
 @app.callback(

--- a/data_parser.py
+++ b/data_parser.py
@@ -274,7 +274,7 @@ def filter_parsed_mutations_by_freq(parsed_mutations, min_mutation_freq,
     return ret
 
 
-def get_data(dirs, clade_defining=False, hidden_strains=None,
+def get_data(dirs, show_clade_defining=False, hidden_strains=None,
              strain_order=None, min_mutation_freq=None,
              max_mutation_freq=None):
     """Get relevant data for Plotly visualizations in this application.
@@ -294,8 +294,9 @@ def get_data(dirs, clade_defining=False, hidden_strains=None,
 
     :param dirs: List of paths to folders to obtain data from
     :type dirs: list[str]
-    :param clade_defining: Set non-clade defining mutations as hidden
-    :type clade_defining: bool
+    :param show_clade_defining: Set non-clade defining mutations as
+        hidden.
+    :type show_clade_defining: bool
     :param hidden_strains: List of strains from the dirs that the user
         does not want to display in the heatmap and table.
     :type hidden_strains: list[str]
@@ -345,7 +346,7 @@ def get_data(dirs, clade_defining=False, hidden_strains=None,
     visible_parsed_mutations = \
         {k: v for k, v in parsed_mutations.items() if k not in hidden_strains}
 
-    if clade_defining:
+    if show_clade_defining:
         visible_parsed_mutations = \
             filter_parsed_mutations_by_clade_defining(visible_parsed_mutations)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 dash==1.20.0
 pandas==1.2.0
 dash-bootstrap-components==0.11.3
+Flask-Caching==1.10.1
 gunicorn==20.1.0


### PR DESCRIPTION
Utilize cache and signaling for get_data ret 

* ``data`` dcc var now only used in clientside callbacks

* ``get-data-args`` used in serverside callbacks

* ``read_data`` calls and caches ``get_data`` with ```get-data-args``

* Using filesystem cache