### PR TITLE
Prevent upload conflicts with hidden strains

### DIFF
--- a/app.py
+++ b/app.py
@@ -379,7 +379,7 @@ def update_new_upload(file_contents, filename, get_data_args, last_data_mtime):
     if ext != "vcf":
         status = "error"
         msg = "Filename must end in \".vcf\"."
-    elif new_strain in old_data["heatmap_y_strains"]:
+    elif new_strain in old_data["all_strains"]:
         status = "error"
         msg = "Filename must not conflict with existing variant."
     else:

--- a/data_parser.py
+++ b/data_parser.py
@@ -389,7 +389,7 @@ def get_data(dirs, show_clade_defining=False, hidden_strains=None,
         "voi_strains":
             voi_strains,
         "all_strains":
-            get_heatmap_y_strains(parsed_gvf_dirs),
+            get_heatmap_y_strains(parsed_mutations),
         "mutation_freq_slider_vals":
             mutation_freq_slider_vals,
         "insertions_x":


### PR DESCRIPTION
Resolves #119 

Issue was we were checking upload strain names against ``data["heatmap_y_strains"]``. Now we check against ``data["all_strains"]``.
