### PR TITLE
Do not reload data if strain order stays the same

### DIFF
--- a/app.py
+++ b/app.py
@@ -1181,6 +1181,7 @@ app.clientside_callback(
     Input("new-upload", "data"),
     State({"type": "select-lineages-modal-checklist", "index": ALL}, "id"),
     State("strain-order", "data"),
+    State("data", "data"),
     prevent_initial_call=True
 )
 app.clientside_callback(

--- a/assets/script.js
+++ b/assets/script.js
@@ -42,11 +42,12 @@ window.dash_clientside = Object.assign({}, window.dash_clientside, {
      * @param {Array<Object>} idArray Dash pattern matching id values for
      *  checkboxes in select lineages modal.
      * @param {Object} strainOrder Previous strain order
+     * @param {Object} data ``data_parser.get_data`` return value
      * @return {Array<string>} The strains corresponding the checkboxes in the
      *  select lineages modal, in the final order they were in when the OK
      *  button was clicked.
      */
-    getStrainOrder: (_, newUpload, idArray, strainOrder) => {
+    getStrainOrder: (_, newUpload, idArray, strainOrder, data) => {
       const trigger = dash_clientside.callback_context.triggered[0].prop_id
       if (trigger === 'new-upload.data') {
         if (newUpload['status'] === 'error') {
@@ -80,8 +81,10 @@ window.dash_clientside = Object.assign({}, window.dash_clientside, {
       }
       // Heatmap displays rows in reverse
       ret = ret.reverse()
-      // Do not update if strain order reflects current strain order
-      if (JSON.stringify(ret) === JSON.stringify(strainOrder)) {
+      // Do not update if strain order reflects current strain order. We check
+      // against the implicit strain order because it may not have been
+      // explicitly specified.
+      if (JSON.stringify(ret) === JSON.stringify(data['all_strains'])) {
         return window.dash_clientside.no_update
       } else {
         return ret


### PR DESCRIPTION
Resolves #120 

The issue was that we stopped checking the new strain order against the implicit order in ``data["all_strains"]``. Instead, we checked it against ``strain_order``. This was buggy because ``strain_order`` is empty on page load.
