### PR TITLE
Implement features for jumping through heatmap

### DIFF
--- a/app.py
+++ b/app.py
@@ -188,6 +188,7 @@ def launch_app(_):
         dcc.Store(id="last-histogram-point-clicked"),
         dcc.Store(id="strain-to-del"),
         dcc.Store(id="deleted-strain"),
+        dcc.Store(id="positions-jumped-to"),
         # Used to update certain figures only when necessary
         dcc.Store(id="heatmap-x-len", data=len(data_["heatmap_x_nt_pos"])),
         dcc.Store(id="heatmap-y-strains",
@@ -198,7 +199,6 @@ def launch_app(_):
         dcc.Store(id="make-select-lineages-modal-checkboxes-draggable"),
         dcc.Store(id="make-histogram-rel-pos-bar-dynamic"),
         dcc.Store(id="allow-jumps-from-histogram"),
-        dcc.Store(id="allow-jumps-from-jump-to-modal"),
         dcc.Store(id="link-heatmap-cells-y-scrolling")
     ], None
 
@@ -473,10 +473,11 @@ def trigger_download(_):
     Output("toast-col", "children"),
     Input("new-upload", "data"),
     Input("mutation-freq-slider", "marks"),
+    Input("positions-jumped-to", "data"),
     prevent_initial_call=True
 )
-def toggle_toast(new_upload, _):
-    """Update ``toast-col`` div.
+def toggle_toast(new_upload, _, positions_jumped_to):
+    """Update ``toast-col`` div. TODO
 
     This function shows appropriate toasts when there was following a
     user upload, and re-rendering of mutation frequency vals.
@@ -495,19 +496,31 @@ def toggle_toast(new_upload, _):
             return toast_generator.get_toast(
                 new_upload["msg"],
                 "Success",
-                "success"
+                "success",
+                5000
             )
         if new_upload["status"] == "error":
             return toast_generator.get_toast(
                 new_upload["msg"],
                 "Error",
-                "danger"
+                "danger",
+                5000
             )
     elif "mutation-freq-slider.marks" in triggers:
         return toast_generator.get_toast(
             "Mutation frequency slider vals set to min and max",
             "Info",
-            "info"
+            "info",
+            5000
+        )
+    elif "positions-jumped-to.data" in triggers:
+        msg = "Jumped to strain %s at nucleotide position %s"
+        msg %= (positions_jumped_to["strain"], positions_jumped_to["nt_pos"])
+        return toast_generator.get_toast(
+            msg,
+            "Info",
+            "info",
+            10000
         )
 
 
@@ -1398,7 +1411,7 @@ app.clientside_callback(
         namespace="clientside",
         function_name="jumpToHeatmapPosAfterSelectingMutationName"
     ),
-    Output("allow-jumps-from-jump-to-modal", "data"),
+    Output("positions-jumped-to", "data"),
     Input("jump-to-modal-ok-btn", "n_clicks"),
     State("jump-to-modal-dropdown-search", "value"),
     State("data", "data"),

--- a/app.py
+++ b/app.py
@@ -724,6 +724,22 @@ def toggle_confirm_strain_del_modal(strain_to_del, _, __):
 
 
 @app.callback(
+    Output("jump-to-modal", "is_open"),
+    Input("jump-to-btn", "n_clicks"),
+    Input("jump-to-modal-ok-btn", "n_clicks"),
+    Input("jump-to-modal-cancel-btn", "n_clicks"),
+    prevent_initial_call=True
+)
+def toggle_jump_to_modal(_, __, ___):
+    """TODO"""
+    ctx = dash.callback_context.triggered[0]["prop_id"]
+    if ctx == "jump-to-btn.n_clicks":
+        return True
+    else:
+        return False
+
+
+@app.callback(
     Output("deleted-strain", "data"),
     Input("confirm-strain-del-modal-ok-btn", "n_clicks"),
     State("strain-to-del", "data"),

--- a/app.py
+++ b/app.py
@@ -726,18 +726,23 @@ def toggle_confirm_strain_del_modal(strain_to_del, _, __):
 
 @app.callback(
     Output("jump-to-modal", "is_open"),
+    Output("jump-to-modal-dropdown-search", "options"),
     Input("jump-to-btn", "n_clicks"),
     Input("jump-to-modal-ok-btn", "n_clicks"),
     Input("jump-to-modal-cancel-btn", "n_clicks"),
+    State("get-data-args", "data"),
+    State("last-data-mtime", "data"),
     prevent_initial_call=True
 )
-def toggle_jump_to_modal(_, __, ___):
+def toggle_jump_to_modal(_, __, ___, get_data_args, last_data_mtime):
     """TODO"""
     ctx = dash.callback_context.triggered[0]["prop_id"]
     if ctx == "jump-to-btn.n_clicks":
-        return True
+        # Current ``get_data`` return val
+        data = read_data(get_data_args, last_data_mtime)
+        return True, data["jump_to_dropdown_search_options"]
     else:
-        return False
+        return False, []
 
 
 @app.callback(
@@ -1396,6 +1401,7 @@ app.clientside_callback(
     Output("allow-jumps-from-jump-to-modal", "data"),
     Input("jump-to-modal-ok-btn", "n_clicks"),
     State("jump-to-modal-dropdown-search", "value"),
+    State("data", "data"),
     prevent_initial_call=True
 )
 app.clientside_callback(

--- a/app.py
+++ b/app.py
@@ -183,6 +183,7 @@ def launch_app(_):
         dcc.Store(id="hidden-strains", data=get_data_args["hidden_strains"]),
         dcc.Store(id="strain-order", data=get_data_args["strain_order"]),
         dcc.Store(id="last-heatmap-cell-clicked"),
+        dcc.Store(id="last-histogram-point-clicked"),
         dcc.Store(id="strain-to-del"),
         dcc.Store(id="deleted-strain"),
         # Used to update certain figures only when necessary
@@ -194,6 +195,7 @@ def launch_app(_):
         # functions.
         dcc.Store(id="make-select-lineages-modal-checkboxes-draggable"),
         dcc.Store(id="make-histogram-rel-pos-bar-dynamic"),
+        dcc.Store(id="allow-jumps-from-histogram"),
         dcc.Store(id="link-heatmap-cells-y-scrolling")
     ], None
 
@@ -1204,6 +1206,26 @@ def route_heatmap_cells_fig_click(click_data):
 
 
 @app.callback(
+    Output("histogram", "clickData"),
+    Output("last-histogram-point-clicked", "data"),
+    Input("histogram", "clickData"),
+    prevent_initial_call=True
+)
+def route_histogram_click(click_data):
+    """Store histogram click data in "last-histogram-point-clicked".
+
+    See ``route_heatmap_cells_fig_click`` for more details on logic.
+
+    :param click_data: ``histogram.clickData`` value
+    :type click_data: dict
+    :return: ``None`` to reset histogram ``clickData`` attribute, and a
+        copy of  this attribute before resetting
+    :rtype: (None, dict)
+    """
+    return None, click_data
+
+
+@app.callback(
     Output("mutation-details-modal", "is_open"),
     Output("mutation-details-modal-header", "children"),
     Output("mutation-details-modal-body", "children"),
@@ -1362,6 +1384,16 @@ app.clientside_callback(
     Output("make-histogram-rel-pos-bar-dynamic", "data"),
     Input("heatmap-nt-pos-axis-fig", "figure"),
     State("data", "data")
+)
+app.clientside_callback(
+    ClientsideFunction(
+        namespace="clientside",
+        function_name="jumpToHeatmapPosAfterHistogramClick"
+    ),
+    Output("allow-jumps-from-histogram", "data"),
+    Input("last-histogram-point-clicked", "data"),
+    State("data", "data"),
+    prevent_initial_call=True
 )
 app.clientside_callback(
     ClientsideFunction(

--- a/app.py
+++ b/app.py
@@ -477,15 +477,19 @@ def trigger_download(_):
     prevent_initial_call=True
 )
 def toggle_toast(new_upload, _, positions_jumped_to):
-    """Update ``toast-col`` div. TODO
+    """Update ``toast-col`` div.
 
     This function shows appropriate toasts when there was following a
-    user upload, and re-rendering of mutation frequency vals.
+    user upload, re-rendering of mutation frequency vals, or the
+    heatmap is automatically scrolled to a specific mutation.
 
     :param new_upload: ``update_new_upload`` return value
     :type new_upload: dict
     :param _: Unused input variable that allows re-rendering of the
         mutation frequency slider to trigger this function.
+    :param positions_jumped_to:
+        ``jumpToHeatmapPosAfterSelectingMutationName`` return val.
+    :type positions_jumped_to: dict
     :return: Appropriate Dash Bootstrap Components toast for situation
     :rtype: dbc.Toast
     """
@@ -748,7 +752,21 @@ def toggle_confirm_strain_del_modal(strain_to_del, _, __):
     prevent_initial_call=True
 )
 def toggle_jump_to_modal(_, __, ___, get_data_args, last_data_mtime):
-    """TODO"""
+    """Open or close modal for jumping to mutations.
+
+    This modal opens when a user clicks the toolbar btn for jumping to
+    mutations. It closes when the user clicks the cancel or ok btn in
+    the modal.
+
+    This fn also populates the dropdown content when the modal is
+    opened.
+
+    :param _: User clicked btn in toolbar for opening modal
+    :param __: User clicked ok btn in modal
+    :param ___: User clicked cancel btn in modal
+    :return: Whether modal is open, and the dropdown content if it is
+    :rtype: (bool, list)
+    """
     ctx = dash.callback_context.triggered[0]["prop_id"]
     if ctx == "jump-to-btn.n_clicks":
         # Current ``get_data`` return val

--- a/app.py
+++ b/app.py
@@ -198,6 +198,7 @@ def launch_app(_):
         dcc.Store(id="make-select-lineages-modal-checkboxes-draggable"),
         dcc.Store(id="make-histogram-rel-pos-bar-dynamic"),
         dcc.Store(id="allow-jumps-from-histogram"),
+        dcc.Store(id="allow-jumps-from-jump-to-modal"),
         dcc.Store(id="link-heatmap-cells-y-scrolling")
     ], None
 
@@ -1385,6 +1386,16 @@ app.clientside_callback(
     Output("allow-jumps-from-histogram", "data"),
     Input("last-histogram-point-clicked", "data"),
     State("data", "data"),
+    prevent_initial_call=True
+)
+app.clientside_callback(
+    ClientsideFunction(
+        namespace="clientside",
+        function_name="jumpToHeatmapPosAfterSelectingMutationName"
+    ),
+    Output("allow-jumps-from-jump-to-modal", "data"),
+    Input("jump-to-modal-ok-btn", "n_clicks"),
+    State("jump-to-modal-dropdown-search", "value"),
     prevent_initial_call=True
 )
 app.clientside_callback(

--- a/assets/script.js
+++ b/assets/script.js
@@ -174,14 +174,27 @@ window.dash_clientside = Object.assign({}, window.dash_clientside, {
      * TODO
      */
     jumpToHeatmapPosAfterHistogramClick: (clickData, data) => {
-      // If this is 0, do nothing
       const curveNumber = clickData['points'][0]['curveNumber'];
+      // User clicked histogram plot, not gene bar underneath
+      if (curveNumber === 0) return null;
+
       const geneStartNtPos = clickData['points'][0]['customdata'];
-      let closestNtPos = Number(data['heatmap_x_nt_pos'][0])
-      for (const ntPos of data['heatmap_x_nt_pos']) {
-        if (Number(ntPos) > geneStartNtPos) break
-        closestNtPos = Number(ntPos)
+      let closestNtPosIndex = 0;
+      for (const [i, ntPos] of data['heatmap_x_nt_pos'].entries()) {
+        if (Number(ntPos) > geneStartNtPos) break;
+        closestNtPosIndex++;
       }
+      const closestNtPos = Number(data['heatmap_x_nt_pos'][closestNtPosIndex]);
+
+      const xticks_selector =
+          `#heatmap-nt-pos-axis-fig g.xtick > text:contains(${closestNtPos})`;
+      const $xticks = $(xticks_selector);
+      const xtick_el = $xticks.filter((e) => {
+        return Number($xticks[e].textContent) === closestNtPos;
+      })[0]
+
+      xtick_el.scrollIntoView(false, {inline: 'end'});
+
       return null;
     },
     /**

--- a/assets/script.js
+++ b/assets/script.js
@@ -171,12 +171,16 @@ window.dash_clientside = Object.assign({}, window.dash_clientside, {
       return null
     },
     /**
-     * TODO
+     * Scroll the first column of a gene in the heatmap into view after a user
+     * clicks the corresponding gene in the bar under the histogram.
+     * @param {Object} clickData ``last-histogram-point-clicked`` in-browser var
+     *  val.
+     * @param {Object} data ``data_parser.get_data`` return value
      */
     jumpToHeatmapPosAfterHistogramClick: (clickData, data) => {
       const curveNumber = clickData['points'][0]['curveNumber'];
       // User clicked histogram plot, not gene bar underneath
-      if (curveNumber === 0) return null;
+      if (curveNumber === 0) return;
 
       const geneStartNtPos = clickData['points'][0]['customdata'];
       let closestNtPosIndex = 0;
@@ -194,8 +198,6 @@ window.dash_clientside = Object.assign({}, window.dash_clientside, {
       })[0]
 
       xtick_el.scrollIntoView(false, {inline: 'end'});
-
-      return null;
     },
     /**
      * Using pure JS, link the scrolling of the heatmap cells and y-axis

--- a/assets/script.js
+++ b/assets/script.js
@@ -196,28 +196,47 @@ window.dash_clientside = Object.assign({}, window.dash_clientside, {
       $('#heatmap-center-div')[0].scrollLeft =
           $('#heatmap-nt-pos-axis-fig')[0].offsetWidth;
 
-      const xticks_selector =
+      const xtickSelector =
           `#heatmap-nt-pos-axis-fig g.xtick > text:contains(${closestNtPos})`;
-      const $xticks = $(xticks_selector);
-      const xtick_el = $xticks.filter((e) => {
+      const $xticks = $(xtickSelector);
+      const xtickEl = $xticks.filter((e) => {
         return Number($xticks[e].textContent) === closestNtPos;
       })[0]
 
-      xtick_el.scrollIntoView(false, {inline: 'start'});
+      xtickEl.scrollIntoView(false, {inline: 'start'});
     },
     /**
      * TODO
      */
-    jumpToHeatmapPosAfterSelectingMutationName: (_, val) => {
+    jumpToHeatmapPosAfterSelectingMutationName: (_, val, data) => {
       if (!val) return null;
+
+      const nt_pos = data['mutation_name_dict'][val]['nt_pos'];
+      const strain = data['mutation_name_dict'][val]['strain'];
 
       $('#heatmap-center-div')[0].scrollLeft =
           $('#heatmap-nt-pos-axis-fig')[0].offsetWidth;
+      const xtickEl =
+          $(`#heatmap-nt-pos-axis-fig g.xtick > text:contains(${nt_pos})`)[0];
+      xtickEl.scrollIntoView(false, {inline: 'start'});
 
-      const xticks_selector =
-          `#heatmap-nt-pos-axis-fig g.xtick > text:contains(${val})`;
-      const xtick_el = $(xticks_selector)[0];
-      xtick_el.scrollIntoView(false, {inline: 'start'});
+      // Scrolling the y-tick into view is a bit more complicated due to the
+      // inner and outer container infrastructure.
+
+      const strainsAxisInnerContainerEl =
+          $('#heatmap-strains-axis-inner-container')[0];
+      strainsAxisInnerContainerEl.scrollTop = 0
+
+      const strainsAxisOuterContainerEl =
+          $('#heatmap-strains-axis-outer-container')[0];
+      const strainsAxisOuterContainerBottom =
+          strainsAxisOuterContainerEl.getBoundingClientRect().bottom;
+      const ytickEl =
+          $(`#heatmap-strains-axis-fig g.ytick > text:contains(${strain})`)[0];
+      const ytickBottom =
+          ytickEl.getBoundingClientRect().bottom;
+      strainsAxisInnerContainerEl.scrollTop =
+          ytickBottom - strainsAxisOuterContainerBottom;
 
       return null;
     },

--- a/assets/script.js
+++ b/assets/script.js
@@ -178,6 +178,9 @@ window.dash_clientside = Object.assign({}, window.dash_clientside, {
      * @param {Object} data ``data_parser.get_data`` return value
      */
     jumpToHeatmapPosAfterHistogramClick: (clickData, data) => {
+      // New histogram resets click data
+      if (!clickData) return;
+
       const curveNumber = clickData['points'][0]['curveNumber'];
       // User clicked histogram plot, not gene bar underneath
       if (curveNumber === 0) return;

--- a/assets/script.js
+++ b/assets/script.js
@@ -238,7 +238,7 @@ window.dash_clientside = Object.assign({}, window.dash_clientside, {
       strainsAxisInnerContainerEl.scrollTop =
           ytickBottom - strainsAxisOuterContainerBottom;
 
-      return null;
+      return {"strain": strain, "nt_pos": nt_pos};
     },
     /**
      * Using pure JS, link the scrolling of the heatmap cells and y-axis

--- a/assets/script.js
+++ b/assets/script.js
@@ -171,6 +171,20 @@ window.dash_clientside = Object.assign({}, window.dash_clientside, {
       return null
     },
     /**
+     * TODO
+     */
+    jumpToHeatmapPosAfterHistogramClick: (clickData, data) => {
+      // If this is 0, do nothing
+      const curveNumber = clickData['points'][0]['curveNumber'];
+      const geneStartNtPos = clickData['points'][0]['customdata'];
+      let closestNtPos = Number(data['heatmap_x_nt_pos'][0])
+      for (const ntPos of data['heatmap_x_nt_pos']) {
+        if (Number(ntPos) > geneStartNtPos) break
+        closestNtPos = Number(ntPos)
+      }
+      return null;
+    },
+    /**
      * Using pure JS, link the scrolling of the heatmap cells and y-axis
      * containers.
      * Lifted from https://stackoverflow.com/a/41998497/11472358

--- a/assets/script.js
+++ b/assets/script.js
@@ -206,7 +206,13 @@ window.dash_clientside = Object.assign({}, window.dash_clientside, {
       xtickEl.scrollIntoView(false, {inline: 'start'});
     },
     /**
-     * TODO
+     * Scroll the first row and column of a mutation in the heatmap into view
+     * after a user selects a mutation in the modal for jumping to mutations.
+     * @param _ User clicked the okay btn in the modal for jumping to
+     *  mutations.
+     * @param {string} val Mutation selected by user
+     * @param {Object} data ``data_parser.get_data`` return value
+     * @return {Object} Info on strain and nt pos heatmap jumped to
      */
     jumpToHeatmapPosAfterSelectingMutationName: (_, val, data) => {
       if (!val) return null;

--- a/assets/script.js
+++ b/assets/script.js
@@ -193,6 +193,9 @@ window.dash_clientside = Object.assign({}, window.dash_clientside, {
       }
       const closestNtPos = Number(data['heatmap_x_nt_pos'][closestNtPosIndex]);
 
+      $('#heatmap-center-div')[0].scrollLeft =
+          $('#heatmap-nt-pos-axis-fig')[0].offsetWidth;
+
       const xticks_selector =
           `#heatmap-nt-pos-axis-fig g.xtick > text:contains(${closestNtPos})`;
       const $xticks = $(xticks_selector);
@@ -200,7 +203,23 @@ window.dash_clientside = Object.assign({}, window.dash_clientside, {
         return Number($xticks[e].textContent) === closestNtPos;
       })[0]
 
-      xtick_el.scrollIntoView(false, {inline: 'end'});
+      xtick_el.scrollIntoView(false, {inline: 'start'});
+    },
+    /**
+     * TODO
+     */
+    jumpToHeatmapPosAfterSelectingMutationName: (_, val) => {
+      if (!val) return null;
+
+      $('#heatmap-center-div')[0].scrollLeft =
+          $('#heatmap-nt-pos-axis-fig')[0].offsetWidth;
+
+      const xticks_selector =
+          `#heatmap-nt-pos-axis-fig g.xtick > text:contains(${val})`;
+      const xtick_el = $(xticks_selector)[0];
+      xtick_el.scrollIntoView(false, {inline: 'start'});
+
+      return null;
     },
     /**
      * Using pure JS, link the scrolling of the heatmap cells and y-axis

--- a/data_parser.py
+++ b/data_parser.py
@@ -323,7 +323,9 @@ def get_data(dirs, show_clade_defining=False, hidden_strains=None,
             get_heatmap_mutation_fns(visible_parsed_mutations,
                                      max_mutations_per_pos_dict),
         "heatmap_x_genes":
-            get_heatmap_x_genes(max_mutations_per_pos_dict)
+            get_heatmap_x_genes(max_mutations_per_pos_dict),
+        "mutation_name_dict":
+            get_mutation_name_dict(visible_parsed_mutations)
     }
     ret["heatmap_x_tickvals"] = \
         get_heatmap_x_tickvals(ret["heatmap_cells_tickvals"])
@@ -333,6 +335,8 @@ def get_data(dirs, show_clade_defining=False, hidden_strains=None,
     ret["heatmap_cells_container_height"] = \
         min(10*40, ret["heatmap_cells_fig_height"])
     ret["heatmap_cells_fig_width"] = len(ret["heatmap_x_nt_pos"]) * 36
+    ret["jump_to_dropdown_search_options"] = \
+        get_jump_to_dropdown_search_options(ret["mutation_name_dict"])
 
     return ret
 
@@ -619,6 +623,26 @@ def get_heatmap_hover_text(parsed_mutations, max_mutations_per_pos_dict):
                     cols[i] = cell_text_str % cell_text_params
             row.extend(cols)
         ret.append(row)
+    return ret
+
+
+def get_mutation_name_dict(parsed_mutations):
+    """TODO"""
+    ret = {}
+    for strain in reversed(parsed_mutations):
+        for nt_pos in parsed_mutations[strain]:
+            for mutation in parsed_mutations[strain][nt_pos]:
+                mutation_name = mutation["mutation_name"]
+                if mutation_name and mutation_name not in ret:
+                    ret[mutation_name] = {"strain": strain, "nt_pos": nt_pos}
+    return ret
+
+
+def get_jump_to_dropdown_search_options(mutation_name_dict):
+    """TODO"""
+    ret = []
+    for mutation_name in mutation_name_dict:
+        ret.append({"label": mutation_name, "value": mutation_name})
     return ret
 
 

--- a/data_parser.py
+++ b/data_parser.py
@@ -627,7 +627,17 @@ def get_heatmap_hover_text(parsed_mutations, max_mutations_per_pos_dict):
 
 
 def get_mutation_name_dict(parsed_mutations):
-    """TODO"""
+    """Get dict containing strain and nt pos of mutations.
+
+    For each unique mutation, we assign the top-left most strain and
+    pos seen in the heatmap with the corresponding mutation.
+
+    :param parsed_mutations: A dictionary containing multiple merged
+        ``get_parsed_gvf_dir`` return "mutations" values.
+    :type parsed_mutations: dict
+    :return: Dict with mutation names and their strains/positions
+    :type: dict
+    """
     ret = {}
     for strain in reversed(parsed_mutations):
         for nt_pos in parsed_mutations[strain]:
@@ -639,7 +649,13 @@ def get_mutation_name_dict(parsed_mutations):
 
 
 def get_jump_to_dropdown_search_options(mutation_name_dict):
-    """TODO"""
+    """List of dash bootstrap options corresponding to mutation dict.
+
+    @param mutation_name_dict: ``get_mutation_name_dict`` ret val
+    @type mutation_name_dict: dict
+    @return: List of dicts with a label and val key
+    @rtype: list
+    """
     ret = []
     for mutation_name in mutation_name_dict:
         ret.append({"label": mutation_name, "value": mutation_name})

--- a/generators/histogram_generator.py
+++ b/generators/histogram_generator.py
@@ -252,7 +252,8 @@ def get_histogram_gene_bar_obj_list():
                                         "line": {"width": 0}
                                     },
                                     showlegend=False,
-                                    hovertemplate=gene)
+                                    hovertemplate=gene,
+                                    customdata=[gene_start])
         ret.append(intragenic_bar_obj)
 
     return ret

--- a/generators/legend_generator.py
+++ b/generators/legend_generator.py
@@ -72,9 +72,17 @@ def get_legend_rows():
             no_gutters=True
         ),
         dbc.Row(
-            dbc.Col(html.B("Note: you can zoom out of your browser to view "
-                           "more cells at a time--the visualization will "
-                           "scale."),
+            dbc.Col(html.B("You can zoom out of your browser to view more "
+                           "cells at a time--the visualization will scale."),
+                    className="border-bottom border-left border-right "
+                              "border-dark p-1",
+                    width={"offset": 1, "size": 10}),
+            no_gutters=True
+        ),
+        dbc.Row(
+            dbc.Col(html.B("Click on a gene/region in the bar below the "
+                           "histogram to automatically scroll to the "
+                           "beginning of that gene/region in the heatmap."),
                     className="border-bottom border-left border-right "
                               "border-dark p-1",
                     width={"offset": 1, "size": 10}),

--- a/generators/toast_generator.py
+++ b/generators/toast_generator.py
@@ -20,7 +20,7 @@ def get_toast_row():
 
 
 def get_toast(msg, header, color, duration):
-    """Get toast div.TODO
+    """Get toast div.
 
     @param msg: Message in toast body
     @type msg: str
@@ -28,6 +28,8 @@ def get_toast(msg, header, color, duration):
     @type header: str
     @param color: Bootstrap color of icon in toast header
     @type color: str
+    @param duration: Time in ms for toast before auto-dismissing
+    @type duration: int
     @return: Toast with user-specified content
     @rtype: dbc.Toast
     """

--- a/generators/toast_generator.py
+++ b/generators/toast_generator.py
@@ -19,8 +19,8 @@ def get_toast_row():
     return ret
 
 
-def get_toast(msg, header, color):
-    """Get toast div.
+def get_toast(msg, header, color, duration):
+    """Get toast div.TODO
 
     @param msg: Message in toast body
     @type msg: str
@@ -36,6 +36,6 @@ def get_toast(msg, header, color):
         header=header,
         className="mt-1",
         dismissable=True,
-        duration=5000,
+        duration=duration,
         icon=color
     )

--- a/generators/toast_generator.py
+++ b/generators/toast_generator.py
@@ -1,0 +1,41 @@
+"""Functions for generating toast views."""
+
+import dash_bootstrap_components as dbc
+
+
+def get_toast_row():
+    """Get Dash Bootstrap Components row that contains toasts.
+
+    :return: Dash Bootstrap Component row with toasts.
+    :rtype: dbc.Row
+    """
+    ret = dbc.Row(
+        dbc.Col(
+            None,
+            id="toast-col",
+            width={"offset": 1, "size": 10}
+        )
+    )
+    return ret
+
+
+def get_toast(msg, header, color):
+    """Get toast div.
+
+    @param msg: Message in toast body
+    @type msg: str
+    @param header: Message in toast header
+    @type header: str
+    @param color: Bootstrap color of icon in toast header
+    @type color: str
+    @return: Toast with user-specified content
+    @rtype: dbc.Toast
+    """
+    return dbc.Toast(
+        msg,
+        header=header,
+        className="mt-1",
+        dismissable=True,
+        duration=5000,
+        icon=color
+    )

--- a/generators/toolbar_generator.py
+++ b/generators/toolbar_generator.py
@@ -267,9 +267,21 @@ def get_jump_to_modal():
     """TODO"""
     return dbc.Modal([
         dbc.ModalHeader("Jump to mutation"),
-        # Empty at launch; populated when user opens modal
-        dbc.ModalBody(None,
-                      id="jump-to-modal-body"),
+        dbc.ModalBody(
+            dbc.Row(
+                dbc.Col(
+                    dcc.Dropdown(
+                        id="jump-to-modal-dropdown-search",
+                        options=[
+                            {"label": "p.N2596S", "value": 8052},
+                            {"label": "p.V4997G", "value": 15254},
+                            {"label": "c.-3delA", "value": 28270}
+                        ]
+                    )
+                )
+            ),
+            id="jump-to-modal-body"
+        ),
         dbc.ModalFooter(
             dbc.ButtonGroup([
                 dbc.Button("Cancel",

--- a/generators/toolbar_generator.py
+++ b/generators/toolbar_generator.py
@@ -272,11 +272,8 @@ def get_jump_to_modal():
                 dbc.Col(
                     dcc.Dropdown(
                         id="jump-to-modal-dropdown-search",
-                        options=[
-                            {"label": "p.N2596S", "value": 8052},
-                            {"label": "p.V4997G", "value": 15254},
-                            {"label": "c.-3delA", "value": 28270}
-                        ]
+                        # Populate when opening modal
+                        options=[]
                     )
                 )
             ),

--- a/generators/toolbar_generator.py
+++ b/generators/toolbar_generator.py
@@ -10,12 +10,11 @@ from definitions import USER_DATA_DIR
 
 
 def get_toolbar_row(data):
-    """Get Dash Bootstrap Components row that sits above heatmap.
+    """Get Dash Bootstrap Components row that contains toolbar.
 
     :param data: ``get_data`` return value
     :type data: dict
-    :return: Dash Bootstrap Component row with upload button and clade
-        defining mutations switch.
+    :return: Dash Bootstrap Component row with toolbar btns.
     :rtype: dbc.Row
     """
     ret = dbc.Row(
@@ -35,12 +34,7 @@ def get_toolbar_row(data):
                     ],
                     className="pl-4 pl-xl-5"
                 ),
-                width=4
-            ),
-            dbc.Col(
-                # Empty on launch
-                className="my-auto",
-                id="dialog-col"
+                width=7
             ),
             dbc.Col(
                 [

--- a/generators/toolbar_generator.py
+++ b/generators/toolbar_generator.py
@@ -255,7 +255,12 @@ def get_file_download_component():
 
 
 def get_jump_to_btn():
-    """TODO"""
+    """Returns button for opening modal for jumping to mutations.
+
+    :return: Dash Bootstrap Components button with appropriate label
+        for jumping to mutations.
+    :rtype: dbc.Button
+    """
     return dbc.Button("Jump to...",
                       color="secondary",
                       outline=True,
@@ -264,7 +269,14 @@ def get_jump_to_btn():
 
 
 def get_jump_to_modal():
-    """TODO"""
+    """Returns modal for jumping to mutations.
+
+    This modal is initially closed, and the body is empty.
+
+    :return: Initially closed Dash Bootstrap Components modal for
+        jumping to mutations.
+    :rtype: dbc.Modal
+    """
     return dbc.Modal([
         dbc.ModalHeader("Jump to mutation"),
         dbc.ModalBody(

--- a/generators/toolbar_generator.py
+++ b/generators/toolbar_generator.py
@@ -30,6 +30,7 @@ def get_toolbar_row(data):
                             type="circle"
                         ),
                         get_file_download_component(),
+                        get_jump_to_btn(),
                         get_legend_toggle_component()
                     ],
                     className="pl-4 pl-xl-5"
@@ -66,7 +67,8 @@ def get_toolbar_row(data):
                 width=2
             ),
             get_select_lineages_modal(),
-            get_confirm_strain_del_modal()
+            get_confirm_strain_del_modal(),
+            get_jump_to_modal()
         ],
         className="mt-3 ml-xl-3"
     )
@@ -252,6 +254,36 @@ def get_file_download_component():
     ], className="mr-2")
 
 
+def get_jump_to_btn():
+    """TODO"""
+    return dbc.Button("Jump to...",
+                      color="secondary",
+                      outline=True,
+                      id="jump-to-btn",
+                      className="mr-2")
+
+
+def get_jump_to_modal():
+    """TODO"""
+    return dbc.Modal([
+        dbc.ModalHeader("Jump to mutation"),
+        # Empty at launch; populated when user opens modal
+        dbc.ModalBody(None,
+                      id="jump-to-modal-body"),
+        dbc.ModalFooter(
+            dbc.ButtonGroup([
+                dbc.Button("Cancel",
+                           className="mr-1",
+                           color="secondary",
+                           id="jump-to-modal-cancel-btn"),
+                dbc.Button("Jump",
+                           color="primary",
+                           id="jump-to-modal-ok-btn")
+            ])
+        )
+    ], id="jump-to-modal")
+
+
 def get_legend_toggle_component():
     """Get dash component for toggling heatmap legend.
 
@@ -260,7 +292,6 @@ def get_legend_toggle_component():
     """
     return dbc.Button("HELP",
                       color="info",
-                      # outline=True,
                       id="toggle-legend-btn")
 
 


### PR DESCRIPTION
Closes #133

Users can now click on a gene in the gene bar under the histogram to jump to the beginning of that gene in the heatmap.

Users can also click the ``Jump to...`` btn to select or search for a mutation by name, and the heatmap will automatically scroll to the top-left most mutation with that name. This isn't perfect--the appropriate cell is sometimes a little cut off at the edges, and it isn't always clear where in the heatmap we jumped to due to scrolling constraints. But we do show a toast containing the strain and nt pos we jumped to in order to guide the user. I think this is fine for now.

We replaced the toolbar alerts with automatically dismissing toasts underneath to make room for more btns. This temporarily shifts the heatmap down a few seconds while the toast is activate, but that is fine for now too.

![Peek 2022-09-02 12-48](https://user-images.githubusercontent.com/34198261/188226355-6c28276f-3aef-4d9c-b311-1075ff73e4b0.gif)
