### PR TITLE
Hide hidden mutations from jump to modal

### DIFF
--- a/data_parser.py
+++ b/data_parser.py
@@ -643,7 +643,8 @@ def get_mutation_name_dict(parsed_mutations):
         for nt_pos in parsed_mutations[strain]:
             for mutation in parsed_mutations[strain][nt_pos]:
                 mutation_name = mutation["mutation_name"]
-                if mutation_name and mutation_name not in ret:
+                hidden = mutation["hidden_cell"]
+                if mutation_name and not hidden and mutation_name not in ret:
                     ret[mutation_name] = {"strain": strain, "nt_pos": nt_pos}
     return ret
 


### PR DESCRIPTION
Hidden mutations from hidden strains or hidden mutation frequencies were still showing in the jump to modal. Fixed it. 